### PR TITLE
Adding Coverage Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ Online services for PHP code, provide dashboards. They may use the previous tool
 * [PHP Parser](https://github.com/glayzzle/php-parser) - A NodeJS library for parsing PHP and extracting tokens and AST.
 * [PHPQA](https://edgedesigncz.github.io/phpqa/) - A Wrapper to a lot of PHP tools reported into a single HTML file.
 * [Fixtro](https://github.com/karlosagudo/fixtro) - A wrapper that allow to run in each precommit. It install itself all the dependencies for the runners with a lot of them (phpunit, phpmd, php-cs-fixer, etc..)
+* [Coverage Checker](https://github.com/exussum12/coverageChecker) - A tool which allows some of the tools here to be enforced on changed code only. Good for moving towards new standards


### PR DESCRIPTION
Coverage checker allows standards to be run on pull requests.

all new code added must be PSR-2

or

90% of all code must be covered by a test

The tools takes output from the other files and then filters by the diff between the branch and master