### PR TITLE
Add PHP Architecture Tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Tools to report issues in code that are or lead to bugs.
 * [noverify](https://github.com/VKCOM/noverify) - Pretty fast linter (code static analysis utility) for PHP.
 * [Pfff](https://github.com/facebook/pfff) - Tools for code analysis, visualizations, or style-preserving source transformation.
 * [PHP Analysis](https://github.com/cwi-swat/php-analysis) - A library for analysing and modifying PHP Source Code in Rascal (PHP AiR).
+* [PHP Architecture Tester](https://github.com/carlosas/phpat) - Easy to use architecture testing tool for PHP
 * [PHParch](https://github.com/j6s/phparch.git) - PHPArch is a work in progress architectural testing library for PHP projects. 
 * [PHP Assumption](https://github.com/rskuipers/php-assumptions.git) - Finds <a href="http://rskuipers.com/entry/from-assumptions-to-assertions">weak assumptions</a> in the code, suggest to turn them into stronger validations.
 * [PhpCodeAnalyzer](https://github.com/wapmorgan/PhpCodeAnalyzer.git) - Finds usage of non-built-in extensions.


### PR DESCRIPTION
PHP Architecture Tester is a static analysis tool to verify architectural requirements.
It provides a natural language abstraction to define your own architectural rules and test them against your software.

There are four groups of supported assertions: Dependency, Inheritance, Composition and Mixin.