### PR TITLE
Add PhpStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Tools to measure the code complexity, line of codes, etc.
 * [PHPLOC](https://github.com/sebastianbergmann/phploc) - Utility to measures PHP application size and count various structures.
 * [PHP Metrics](https://github.com/Halleck45/PhpMetrics) - Calculates all sorts of metrics, and display them in a gorgeous interface.
 * [PHP Semantic Versioning Checker](https://github.com/tomzx/php-semver-checker) - Compares two source sets and determines the appropriate semantic versioning to apply.
+* [PhpStats](https://github.com/i582/phpstats) - Tool for collecting statistics, metrics, dependencies, and building various graphs for large projects to find bottlenecks.
 * [PhpDependencyAnalysis](https://github.com/mamuz/PhpDependencyAnalysis) - Static code analysis to provide and verify a dependency graph against a defined architecture.
 * [Quality Analyzer](https://github.com/Qafoo/QualityAnalyzer.git) - Quality Analyzer is a tool to visualize metrics and source code.
 


### PR DESCRIPTION
[PhpStats](https://github.com/i582/phpstats) is a CLI tool for collecting statistics, metrics, dependencies, 
and building various graphs.

The tool relies heavily on the speed of work since it was originally created 
to analyze a huge project (about 6 million lines).